### PR TITLE
Support go_docker_compose_test + add example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,14 @@ services:
 
 ### junit_docker_compose_test
 
+(cd examples && bazel test junit-image-test)
+
 In this example, the test source files, dependencies, classpath jars and test image base are passed into the macro. The macro builds a docker image with all of these and then uses the junit standalone jar to execute the tests. You can use some magic customization environment variables in the docker-compose file.
 
 ```starlark
+load("@rules_docker_compose_test//docker_compose_test:docker_compose_test.bzl", "junit_docker_compose_test")
+
+
 junit_docker_compose_test(
     name = "junit-image-test",
     docker_compose_file = ":docker-compose.yml",
@@ -103,6 +108,38 @@ services:
       - JVM_ARGS=-Dfoo.bar=true
 ```
 
+#### javacopts
+
+You can pass `javacopts` when building the uber junit test binary using `uber_jar_javacopts`.
+
+### go_docker_compose_test
+
+```
+(cd examples && bazel test --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 go-test-image-test)
+```
+
+In this example, the test source files, dependencies and test image base are passed into the macro. The macro builds a binary containing the test source files and dependencies which are executed as part of the docker-compose test.
+
+```starlark
+load("@rules_docker_compose_test//docker_compose_test:docker_compose_test.bzl", "go_docker_compose_test")
+
+go_docker_compose_test(
+    name = "go-test-image-test",
+    docker_compose_file = ":docker-compose.yml",
+    docker_compose_test_container = "test_container",
+    test_srcs = glob(["**/*_test.go"]),
+    test_deps = [],
+    test_image_base = "@ubuntu",
+)
+```
+
+```yaml
+services:
+  test_container:
+    image: go-test-image-test:test_container
+    entrypoint: ["tests/go-test-image-test.go_test"]
+```
+
 ## pre_compose_up_script
 
 Sometimes, you may need some logic to run before the compose test containers come up. You can use `pre_compose_up_script` for that purpose. See [examples/pre-compose-up-script-test](examples/pre-compose-up-script-test) for an example.
@@ -110,7 +147,3 @@ Sometimes, you may need some logic to run before the compose test containers com
 ## extra_docker_compose_up_args
 
 You can append extra arguments to the `docker compose up` command using `extra_docker_compose_up_args`. See [examples/pre-compose-up-script-test](examples/pre-compose-up-script-test) for an example.
-
-## javacopts
-
-You can pass `javacopts` when building the uber junit test binary using `uber_jar_javacopts`.

--- a/README.md
+++ b/README.md
@@ -78,13 +78,14 @@ services:
 
 ### junit_docker_compose_test
 
+```
 (cd examples && bazel test junit-image-test)
+```
 
 In this example, the test source files, dependencies, classpath jars and test image base are passed into the macro. The macro builds a docker image with all of these and then uses the junit standalone jar to execute the tests. You can use some magic customization environment variables in the docker-compose file.
 
 ```starlark
 load("@rules_docker_compose_test//docker_compose_test:docker_compose_test.bzl", "junit_docker_compose_test")
-
 
 junit_docker_compose_test(
     name = "junit-image-test",

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -22,9 +22,9 @@ local_repository(
 
 http_archive(
     name = "rules_oci",
-    sha256 = "4a276e9566c03491649eef63f27c2816cc222f41ccdebd97d2c5159e84917c3b",
-    strip_prefix = "rules_oci-1.7.4",
-    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.7.4/rules_oci-v1.7.4.tar.gz",
+    sha256 = "46ce9edcff4d3d7b3a550774b82396c0fa619cc9ce9da00c1b09a08b45ea5a14",
+    strip_prefix = "rules_oci-1.8.0",
+    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.8.0/rules_oci-v1.8.0.tar.gz",
 )
 
 RULES_JVM_EXTERNAL_TAG = "6.0"
@@ -54,6 +54,16 @@ oci_pull(
     # tag = "debug", # debug distroless image can be debugged with --entrypoint "/busybox/sh"
     digest = "sha256:73c3687a9d7277f480a560ae380ba16acbe8eb5a0f459560b4466bb71e6288a1",
     image = "gcr.io/distroless/java17",
+)
+
+oci_pull(
+    name = "ubuntu",
+    digest = "sha256:278628f08d4979fb9af9ead44277dbc9c92c2465922310916ad0c46ec9999295",
+    image = "ubuntu",
+    platforms = [
+        "linux/amd64",
+        "linux/arm64/v8",
+    ],
 )
 
 load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
@@ -86,3 +96,7 @@ rules_docker_compose_test_repositories()
 load("@rules_docker_compose_test//:setup.bzl", "rules_docker_compose_test_dependencies", "repo_absolute_path")
 rules_docker_compose_test_dependencies()
 repo_absolute_path(name="repo_absolute_path")
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+go_rules_dependencies()
+go_register_toolchains(version = "1.23.0")

--- a/examples/go-test-image-test/BUILD.bazel
+++ b/examples/go-test-image-test/BUILD.bazel
@@ -1,0 +1,25 @@
+# Copyright (c) 2024, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_docker_compose_test//docker_compose_test:docker_compose_test.bzl", "go_docker_compose_test")
+
+go_docker_compose_test(
+    name = "go-test-image-test",
+    docker_compose_file = ":docker-compose.yml",
+    docker_compose_test_container = "test_container",
+    test_srcs = glob(["**/*_test.go"]),
+    test_deps = [],
+    test_image_base = "@ubuntu",
+)

--- a/examples/go-test-image-test/another_test.go
+++ b/examples/go-test-image-test/another_test.go
@@ -1,0 +1,7 @@
+package main
+
+import "testing"
+
+func TestExample2(t *testing.T) {
+	  t.Log("bar")
+}

--- a/examples/go-test-image-test/docker-compose.yml
+++ b/examples/go-test-image-test/docker-compose.yml
@@ -1,0 +1,19 @@
+# Copyright (c) 2023, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  test_container:
+    image: go-test-image-test:test_container
+    entrypoint: ["tests/go-test-image-test.go_test"]

--- a/examples/go-test-image-test/docker-compose.yml
+++ b/examples/go-test-image-test/docker-compose.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Salesforce, Inc.
+# Copyright (c) 2024, Salesforce, Inc.
 # SPDX-License-Identifier: Apache-2
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/go-test-image-test/example_test.go
+++ b/examples/go-test-image-test/example_test.go
@@ -1,0 +1,7 @@
+package main
+
+import "testing"
+
+func TestExample(t *testing.T) {
+	  t.Log("foo")
+}

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -30,7 +30,25 @@ def rules_docker_compose_test_repositories():
 
     http_archive(
         name = "rules_oci",
-        sha256 = "4a276e9566c03491649eef63f27c2816cc222f41ccdebd97d2c5159e84917c3b",
-        strip_prefix = "rules_oci-1.7.4",
-        url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.7.4/rules_oci-v1.7.4.tar.gz",
+        sha256 = "46ce9edcff4d3d7b3a550774b82396c0fa619cc9ce9da00c1b09a08b45ea5a14",
+        strip_prefix = "rules_oci-1.8.0",
+        url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.8.0/rules_oci-v1.8.0.tar.gz",
+    )
+
+    http_archive(
+        name = "io_bazel_rules_go",
+        sha256 = "f4a9314518ca6acfa16cc4ab43b0b8ce1e4ea64b81c38d8a3772883f153346b8",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip",
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip",
+        ],
+    )
+
+    http_archive(
+        name = "platforms",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+        ],
+        sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
     )


### PR DESCRIPTION
This allows to build a binary from the `go_test` input to basically get the same result as running `go test` inside the docker-compose test container.