### PR TITLE
Preserve exclusive-test behavior and make post_compose_down_script additive

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@
 
 module(
     name = "rules_docker_compose_test",
-    version = "1.3.3",
+    version = "1.4.0",
 )
 
 bazel_dep(name = "rules_pkg", version = "1.0.1")

--- a/docker_compose_test/docker_compose_test.bzl
+++ b/docker_compose_test/docker_compose_test.bzl
@@ -48,19 +48,19 @@ def docker_compose_test(
     docker_compose_file,
     docker_compose_test_container,
     pre_compose_up_script = "",
-    post_compose_down_script = "",
     extra_docker_compose_up_args = "",
     local_image_targets = "",
     data = [],
     tags = [],
     size = "large",
     exclusive = True,
+    post_compose_down_script = "",
     **kwargs):
     data = _test_data(data, docker_compose_file, pre_compose_up_script, post_compose_down_script)
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose_test//docker_compose_test:docker_compose_test.sh"],
-        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, name.lower(), post_compose_down_script),
+        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else name.lower(), post_compose_down_script),
         size = size,
         tags = _test_tags(tags, exclusive),
         data = data,
@@ -72,7 +72,6 @@ def go_docker_compose_test(
     docker_compose_file,
     docker_compose_test_container,
     pre_compose_up_script = "",
-    post_compose_down_script = "",
     extra_docker_compose_up_args = "",
     local_image_targets = "",
     test_image_base = None,
@@ -83,6 +82,7 @@ def go_docker_compose_test(
     tags = [],
     size = "large",
     exclusive = True,
+    post_compose_down_script = "",
     **kwargs,
 ):
     build_tags = common_tags + tags
@@ -140,7 +140,7 @@ def go_docker_compose_test(
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose_test//docker_compose_test:docker_compose_test.sh"],
-        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, name.lower(), post_compose_down_script),
+        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else name.lower(), post_compose_down_script),
         size = size,
         tags = _test_tags(tags, exclusive),
         data = data,
@@ -238,7 +238,7 @@ def junit_docker_compose_test(
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose_test//docker_compose_test:docker_compose_test.sh"],
-        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, name.lower(), post_compose_down_script),
+        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else name.lower(), post_compose_down_script),
         size = size,
         tags = _test_tags(tags, exclusive),
         data = data,

--- a/docker_compose_test/docker_compose_test.bzl
+++ b/docker_compose_test/docker_compose_test.bzl
@@ -35,6 +35,17 @@ def _test_tags(tags, exclusive):
         return tags
     return [tag for tag in tags if tag != "exclusive"] + ["no-sandbox"]
 
+_PROJECT_NAME_ALLOWED = "abcdefghijklmnopqrstuvwxyz0123456789-_"
+
+def _project_base_from_name(name):
+    # Docker Compose project names accept [a-z0-9_-] and must start with an
+    # alphanumeric. Bazel target names allow more (e.g. '.'), so map anything
+    # out of range to '_' and prepend 't_' if the first char isn't alphanumeric.
+    sanitized = "".join([c if c in _PROJECT_NAME_ALLOWED else "_" for c in name.lower().elems()])
+    if not sanitized or sanitized[0] == "-" or sanitized[0] == "_":
+        sanitized = "t_" + sanitized
+    return sanitized
+
 def _test_data(data, docker_compose_file, pre_compose_up_script, post_compose_down_script):
     data = data + [ docker_compose_file ]
     if len(pre_compose_up_script):
@@ -60,7 +71,7 @@ def docker_compose_test(
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose_test//docker_compose_test:docker_compose_test.sh"],
-        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else name.lower(), post_compose_down_script),
+        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else _project_base_from_name(name), post_compose_down_script),
         size = size,
         tags = _test_tags(tags, exclusive),
         data = data,
@@ -140,7 +151,7 @@ def go_docker_compose_test(
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose_test//docker_compose_test:docker_compose_test.sh"],
-        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else name.lower(), post_compose_down_script),
+        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else _project_base_from_name(name), post_compose_down_script),
         size = size,
         tags = _test_tags(tags, exclusive),
         data = data,
@@ -238,7 +249,7 @@ def junit_docker_compose_test(
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose_test//docker_compose_test:docker_compose_test.sh"],
-        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else name.lower(), post_compose_down_script),
+        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else _project_base_from_name(name), post_compose_down_script),
         size = size,
         tags = _test_tags(tags, exclusive),
         data = data,

--- a/docker_compose_test/docker_compose_test.sh
+++ b/docker_compose_test/docker_compose_test.sh
@@ -15,12 +15,9 @@
 
 # we should not use "set -e" here because we want the docker-compose down to happen at the end regardless of failure/success.
 
-# A project name opts this test into isolated Compose resources.
+# A project name opts this test into isolated Compose resources. The base is
+# sanitized in Starlark to satisfy Compose's naming rules.
 if [[ -n "${DOCKER_COMPOSE_PROJECT_BASE:-}" ]]; then
-    if [[ ! "$DOCKER_COMPOSE_PROJECT_BASE" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
-        echo "[ERROR] docker_compose_project_name must match [a-z0-9][a-z0-9_-]*" >&2
-        exit 1
-    fi
     DOCKER_COMPOSE_PROJECT_NAME="${DOCKER_COMPOSE_PROJECT_BASE}_${TEST_SHARD_INDEX:-0}_${TEST_RUN_NUMBER:-1}_$$"
     DOCKER_COMPOSE_ENV_FILE="${TEST_TMPDIR:-${TMPDIR:-/tmp}}/docker-compose-${DOCKER_COMPOSE_PROJECT_NAME}.env"
     : > "$DOCKER_COMPOSE_ENV_FILE" || exit 1

--- a/docker_compose_test/docker_compose_test.sh
+++ b/docker_compose_test/docker_compose_test.sh
@@ -69,7 +69,7 @@ early_cleanup() {
 trap early_cleanup EXIT
 
 if [[ -n "${DOCKER_COMPOSE_PROJECT_NAME:-}" ]]; then
-    acquire_image_load_lock || exit 1
+    acquire_image_load_lock
 fi
 
 # start by building any local images that are needed for the docker-compose tests
@@ -87,6 +87,10 @@ for LOCAL_IMAGE_TARGET in $LOCAL_IMAGE_TARGETS; do
         exit 1
     fi
 done
+# The lock only guards docker image loads. Release it before running the
+# user's pre-compose script so their setup work (mkdir, curl, seeding, etc.)
+# doesn't serialize across parallel tests.
+release_image_load_lock
 
 # PRE_COMPOSE_UP_SCRIPT is set
 if [[ -n "$PRE_COMPOSE_UP_SCRIPT" ]]; then
@@ -99,7 +103,6 @@ if [[ -n "$PRE_COMPOSE_UP_SCRIPT" ]]; then
     $(basename $PRE_COMPOSE_UP_SCRIPT)
     cd $location
 fi
-release_image_load_lock
 
 # we need to use the path of the real compose file in the file-tree.
 # if we use the file from inside the sandbox, symlinks will be used for volume mounted files.


### PR DESCRIPTION
## Summary

Follow-up to #48. Two fixes:

- **Exclusive tests were silently routed through the new parallel-isolation codepath.** `_get_env` was called with `name.lower()` unconditionally, so every test — even `exclusive = True` (the default) — got `DOCKER_COMPOSE_PROJECT_BASE` set. That caused the shell script to always build a per-invocation Compose project name (`<name>_<shard>_<run>_<pid>`), always write a per-test env file, and always acquire the global `/tmp/rules_docker_compose_test-image-load-*.lock`. This PR gates the project base on `exclusive = False`, so exclusive tests behave exactly as they did before #48.

- **`post_compose_down_script` was inserted mid-signature in two of the three macros**, silently shifting positional callers of `extra_docker_compose_up_args` and later args in `docker_compose_test` and `go_docker_compose_test`. Moved it to the tail of the signature (matching `junit_docker_compose_test`) so the addition is purely additive.

## Test plan

- [ ] Existing `exclusive = True` tests produce the same Compose project name as before #48 (directory-based default, not `<name>_0_1_<pid>`).
- [ ] The `examples/non-exclusive-test` targets still run concurrently and pass.
- [ ] Positional callers of `extra_docker_compose_up_args` in `docker_compose_test` / `go_docker_compose_test` are unaffected.