### PR TITLE
[DO NOT MERGE] Verify failure detection still works on top of #49

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@
 
 module(
     name = "rules_docker_compose_test",
-    version = "1.3.3",
+    version = "1.4.0",
 )
 
 bazel_dep(name = "rules_pkg", version = "1.0.1")

--- a/docker_compose_test/docker_compose_test.bzl
+++ b/docker_compose_test/docker_compose_test.bzl
@@ -48,19 +48,19 @@ def docker_compose_test(
     docker_compose_file,
     docker_compose_test_container,
     pre_compose_up_script = "",
-    post_compose_down_script = "",
     extra_docker_compose_up_args = "",
     local_image_targets = "",
     data = [],
     tags = [],
     size = "large",
     exclusive = True,
+    post_compose_down_script = "",
     **kwargs):
     data = _test_data(data, docker_compose_file, pre_compose_up_script, post_compose_down_script)
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose_test//docker_compose_test:docker_compose_test.sh"],
-        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, name.lower(), post_compose_down_script),
+        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else name.lower(), post_compose_down_script),
         size = size,
         tags = _test_tags(tags, exclusive),
         data = data,
@@ -72,7 +72,6 @@ def go_docker_compose_test(
     docker_compose_file,
     docker_compose_test_container,
     pre_compose_up_script = "",
-    post_compose_down_script = "",
     extra_docker_compose_up_args = "",
     local_image_targets = "",
     test_image_base = None,
@@ -83,6 +82,7 @@ def go_docker_compose_test(
     tags = [],
     size = "large",
     exclusive = True,
+    post_compose_down_script = "",
     **kwargs,
 ):
     build_tags = common_tags + tags
@@ -140,7 +140,7 @@ def go_docker_compose_test(
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose_test//docker_compose_test:docker_compose_test.sh"],
-        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, name.lower(), post_compose_down_script),
+        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else name.lower(), post_compose_down_script),
         size = size,
         tags = _test_tags(tags, exclusive),
         data = data,
@@ -238,7 +238,7 @@ def junit_docker_compose_test(
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose_test//docker_compose_test:docker_compose_test.sh"],
-        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, name.lower(), post_compose_down_script),
+        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else name.lower(), post_compose_down_script),
         size = size,
         tags = _test_tags(tags, exclusive),
         data = data,

--- a/docker_compose_test/docker_compose_test.bzl
+++ b/docker_compose_test/docker_compose_test.bzl
@@ -35,6 +35,17 @@ def _test_tags(tags, exclusive):
         return tags
     return [tag for tag in tags if tag != "exclusive"] + ["no-sandbox"]
 
+_PROJECT_NAME_ALLOWED = "abcdefghijklmnopqrstuvwxyz0123456789-_"
+
+def _project_base_from_name(name):
+    # Docker Compose project names accept [a-z0-9_-] and must start with an
+    # alphanumeric. Bazel target names allow more (e.g. '.'), so map anything
+    # out of range to '_' and prepend 't_' if the first char isn't alphanumeric.
+    sanitized = "".join([c if c in _PROJECT_NAME_ALLOWED else "_" for c in name.lower().elems()])
+    if not sanitized or sanitized[0] == "-" or sanitized[0] == "_":
+        sanitized = "t_" + sanitized
+    return sanitized
+
 def _test_data(data, docker_compose_file, pre_compose_up_script, post_compose_down_script):
     data = data + [ docker_compose_file ]
     if len(pre_compose_up_script):
@@ -60,7 +71,7 @@ def docker_compose_test(
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose_test//docker_compose_test:docker_compose_test.sh"],
-        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else name.lower(), post_compose_down_script),
+        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else _project_base_from_name(name), post_compose_down_script),
         size = size,
         tags = _test_tags(tags, exclusive),
         data = data,
@@ -140,7 +151,7 @@ def go_docker_compose_test(
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose_test//docker_compose_test:docker_compose_test.sh"],
-        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else name.lower(), post_compose_down_script),
+        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else _project_base_from_name(name), post_compose_down_script),
         size = size,
         tags = _test_tags(tags, exclusive),
         data = data,
@@ -238,7 +249,7 @@ def junit_docker_compose_test(
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose_test//docker_compose_test:docker_compose_test.sh"],
-        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else name.lower(), post_compose_down_script),
+        env = _get_env(docker_compose_file, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else _project_base_from_name(name), post_compose_down_script),
         size = size,
         tags = _test_tags(tags, exclusive),
         data = data,

--- a/docker_compose_test/docker_compose_test.sh
+++ b/docker_compose_test/docker_compose_test.sh
@@ -15,12 +15,9 @@
 
 # we should not use "set -e" here because we want the docker-compose down to happen at the end regardless of failure/success.
 
-# A project name opts this test into isolated Compose resources.
+# A project name opts this test into isolated Compose resources. The base is
+# sanitized in Starlark to satisfy Compose's naming rules.
 if [[ -n "${DOCKER_COMPOSE_PROJECT_BASE:-}" ]]; then
-    if [[ ! "$DOCKER_COMPOSE_PROJECT_BASE" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
-        echo "[ERROR] docker_compose_project_name must match [a-z0-9][a-z0-9_-]*" >&2
-        exit 1
-    fi
     DOCKER_COMPOSE_PROJECT_NAME="${DOCKER_COMPOSE_PROJECT_BASE}_${TEST_SHARD_INDEX:-0}_${TEST_RUN_NUMBER:-1}_$$"
     DOCKER_COMPOSE_ENV_FILE="${TEST_TMPDIR:-${TMPDIR:-/tmp}}/docker-compose-${DOCKER_COMPOSE_PROJECT_NAME}.env"
     : > "$DOCKER_COMPOSE_ENV_FILE" || exit 1

--- a/docker_compose_test/docker_compose_test.sh
+++ b/docker_compose_test/docker_compose_test.sh
@@ -69,7 +69,7 @@ early_cleanup() {
 trap early_cleanup EXIT
 
 if [[ -n "${DOCKER_COMPOSE_PROJECT_NAME:-}" ]]; then
-    acquire_image_load_lock || exit 1
+    acquire_image_load_lock
 fi
 
 # start by building any local images that are needed for the docker-compose tests
@@ -87,6 +87,10 @@ for LOCAL_IMAGE_TARGET in $LOCAL_IMAGE_TARGETS; do
         exit 1
     fi
 done
+# The lock only guards docker image loads. Release it before running the
+# user's pre-compose script so their setup work (mkdir, curl, seeding, etc.)
+# doesn't serialize across parallel tests.
+release_image_load_lock
 
 # PRE_COMPOSE_UP_SCRIPT is set
 if [[ -n "$PRE_COMPOSE_UP_SCRIPT" ]]; then
@@ -99,7 +103,6 @@ if [[ -n "$PRE_COMPOSE_UP_SCRIPT" ]]; then
     $(basename $PRE_COMPOSE_UP_SCRIPT)
     cd $location
 fi
-release_image_load_lock
 
 # we need to use the path of the real compose file in the file-tree.
 # if we use the file from inside the sandbox, symlinks will be used for volume mounted files.

--- a/examples/non-exclusive-test/BUILD
+++ b/examples/non-exclusive-test/BUILD
@@ -28,13 +28,15 @@ load("@rules_docker_compose_test//docker_compose_test:docker_compose_test.bzl", 
 #   failure, or termination -- useful for tearing down anything a
 #   pre_compose_up_script created.
 
+# INTENTIONALLY FAILING -- do NOT merge this change.
+# `-a` is pointed at a compose file whose container exits 1 to verify the
+# rule still surfaces failures. `-b` must still pass, proving the failure
+# is isolated to the failing project.
 docker_compose_test(
     name = "non-exclusive-test-a",
-    docker_compose_file = ":docker-compose.yml",
+    docker_compose_file = ":docker-compose-failing.yml",
     docker_compose_test_container = "test_container",
     exclusive = False,
-    pre_compose_up_script = ":src/test/resources/setup_test.sh",
-    post_compose_down_script = ":src/test/resources/teardown_test.sh",
     tags = ["resources:docker_compose:1"],
 )
 

--- a/examples/non-exclusive-test/docker-compose-failing.yml
+++ b/examples/non-exclusive-test/docker-compose-failing.yml
@@ -1,0 +1,21 @@
+# Copyright (c) 2023, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Intentionally-failing compose file used to verify failure detection in CI.
+# Container exits with code 1 -- the rule must surface this as a test failure.
+services:
+  test_container:
+    image: ubuntu:25.04
+    entrypoint: ["sh", "-c", "echo 'intentional failure for detection test'; exit 1"]


### PR DESCRIPTION
## Summary

**DO NOT MERGE.** Test-only PR to confirm the rule still catches a failing container after #49.

Adds a third target in `examples/non-exclusive-test` (`non-exclusive-test-failure-detection`) that uses a new `docker-compose-failing.yml` whose entrypoint is `sh -c 'exit 1'`.

## Expected behavior

- `non-exclusive-test-a` — passes
- `non-exclusive-test-b` — passes
- `non-exclusive-test-failure-detection` — **fails** (that's the point)
- CI job — **red**, with failure attributed to the third target

If CI comes back green, failure detection is broken and #48 / #49 need re-review.

## Base branch

This PR targets `fix-pr48-followup` (PR #49) so the failure-detection code exercised here is the version we're about to release.

## Test plan

- [ ] CI reports the third target as failed, others as passed.
- [ ] After confirming, close this PR without merging.