### PR TITLE
Consolidate compose-files API: kw-only args, plural-only attr

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,6 +16,7 @@
 module(
     name = "rules_docker_compose_test",
     version = "2.0.0",
+    compatibility_level = 2,
 )
 
 bazel_dep(name = "rules_pkg", version = "1.0.1")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@
 
 module(
     name = "rules_docker_compose_test",
-    version = "1.4.0",
+    version = "2.0.0",
 )
 
 bazel_dep(name = "rules_pkg", version = "1.0.1")

--- a/README.md
+++ b/README.md
@@ -173,6 +173,41 @@ services:
     entrypoint: ["tests/go-test-image-test.go_test"]
 ```
 
+## Composing multiple compose files
+
+If a family of tests shares most of a Compose topology, you can factor the
+shared services into a base file and layer per-scenario overrides on top with
+`docker_compose_files` (plural) instead of `docker_compose_file`:
+
+```starlark
+docker_compose_test(
+    name = "multi-compose-file-test",
+    docker_compose_files = [
+        ":base.yml",
+        ":override.yml",
+    ],
+    docker_compose_test_container = "test_container",
+)
+```
+
+Files are passed to `docker compose -f a -f b [-f c ...]` in list order. Compose
+deep-merges them per its
+[multi-file merge semantics](https://docs.docker.com/reference/compose-file/merge/):
+scalars replace, maps merge by key, and **sequences replace wholesale**. If you
+want to add to (rather than replace) a base file's list — e.g. `depends_on` or
+`networks` — use the map form (`depends_on: {svc: {condition: service_healthy}}`)
+so Compose merges by key.
+
+Exactly one of `docker_compose_file` or `docker_compose_files` must be set. See
+[examples/multi-compose-file-test](examples/multi-compose-file-test) for a
+runnable example.
+
+### Keyword-only arguments
+
+All arguments to `docker_compose_test`, `go_docker_compose_test`, and
+`junit_docker_compose_test` must be passed by keyword — including `name`.
+Positional calls will fail at load time.
+
 ## pre_compose_up_script
 
 Sometimes, you may need some logic to run before the compose test containers come up. You can use `pre_compose_up_script` for that purpose. See [examples/pre-compose-up-script-test](examples/pre-compose-up-script-test) for an example.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Check the [latest release](https://github.com/salesforce/rules_docker_compose_te
 
 ## How does it work?
 
-The rule brings up the docker-compose file and validates that the exit code of the test container is `0`.
+The rule brings up the docker-compose file(s) and validates that the exit code of the test container is `0`.
 
 ## Constraints
 
@@ -24,7 +24,7 @@ same time without sharing containers, networks, or volumes:
 ```starlark
 junit_docker_compose_test(
     name = "integration-test",
-    docker_compose_file = ":docker-compose.yml",
+    docker_compose_files = [":docker-compose.yml"],
     docker_compose_test_container = "test_container",
     exclusive = False,
     test_image_base = "@openjdk",
@@ -61,7 +61,7 @@ In this example, the `docker_compose_test` does not actually depend on an image 
 ```starlark
 docker_compose_test(
     name = "junit-image-test",
-    docker_compose_file = ":docker-compose.yml",
+    docker_compose_files = [":docker-compose.yml"],
     docker_compose_test_container = "test_container",
 )
 ```
@@ -94,7 +94,7 @@ sh_binary(
 
 docker_compose_test(
     name = "locally-built-image-test",
-    docker_compose_file = ":docker-compose.yml",
+    docker_compose_files = [":docker-compose.yml"],
     docker_compose_test_container = "test_container",
     local_image_targets = "locally-built-image-test:tarball",
     data = [":docker_image_fixture"],
@@ -121,7 +121,7 @@ load("@rules_docker_compose_test//docker_compose_test:docker_compose_test.bzl", 
 
 junit_docker_compose_test(
     name = "junit-image-test",
-    docker_compose_file = ":docker-compose.yml",
+    docker_compose_files = [":docker-compose.yml"],
     docker_compose_test_container = "test_container",
     test_srcs = glob(["**/*Test.java"]),
     test_deps = ["@maven//:org_junit_jupiter_junit_jupiter_api"],
@@ -158,7 +158,7 @@ load("@rules_docker_compose_test//docker_compose_test:docker_compose_test.bzl", 
 
 go_docker_compose_test(
     name = "go-test-image-test",
-    docker_compose_file = ":docker-compose.yml",
+    docker_compose_files = [":docker-compose.yml"],
     docker_compose_test_container = "test_container",
     test_srcs = glob(["**/*_test.go"]),
     test_deps = [],
@@ -175,9 +175,9 @@ services:
 
 ## Composing multiple compose files
 
-If a family of tests shares most of a Compose topology, you can factor the
-shared services into a base file and layer per-scenario overrides on top with
-`docker_compose_files` (plural) instead of `docker_compose_file`:
+`docker_compose_files` accepts a list, so a family of tests that shares most
+of a Compose topology can factor the shared services into a base file and
+layer per-scenario overrides on top:
 
 ```starlark
 docker_compose_test(
@@ -198,8 +198,7 @@ want to add to (rather than replace) a base file's list — e.g. `depends_on` or
 `networks` — use the map form (`depends_on: {svc: {condition: service_healthy}}`)
 so Compose merges by key.
 
-Exactly one of `docker_compose_file` or `docker_compose_files` must be set. See
-[examples/multi-compose-file-test](examples/multi-compose-file-test) for a
+See [examples/multi-compose-file-test](examples/multi-compose-file-test) for a
 runnable example.
 
 ### Keyword-only arguments

--- a/README.md
+++ b/README.md
@@ -190,13 +190,10 @@ docker_compose_test(
 )
 ```
 
-Files are passed to `docker compose -f a -f b [-f c ...]` in list order. Compose
-deep-merges them per its
-[multi-file merge semantics](https://docs.docker.com/reference/compose-file/merge/):
-scalars replace, maps merge by key, and **sequences replace wholesale**. If you
-want to add to (rather than replace) a base file's list — e.g. `depends_on` or
-`networks` — use the map form (`depends_on: {svc: {condition: service_healthy}}`)
-so Compose merges by key.
+Files are passed to `docker compose -f a -f b [-f c ...]` in list order, so
+later files override earlier ones. See Compose's
+[multi-file merge semantics](https://docs.docker.com/reference/compose-file/merge/)
+for the exact rules.
 
 See [examples/multi-compose-file-test](examples/multi-compose-file-test) for a
 runnable example.

--- a/docker_compose_test/docker_compose_test.bzl
+++ b/docker_compose_test/docker_compose_test.bzl
@@ -46,19 +46,12 @@ def _project_base_from_name(name):
         sanitized = "t_" + sanitized
     return sanitized
 
-def _resolve_compose_files(docker_compose_file, docker_compose_files):
-    # Normalize the singular + plural compose-file attrs into one list.
-    # Exactly one must be set; the singular attr becomes a one-element list.
+def _check_compose_files(docker_compose_files):
     # Order in `docker_compose_files` is preserved through to `docker compose
     # -f <file>` in the same order: later files override earlier files per
     # Compose's multi-file merge semantics.
-    if docker_compose_file != None and len(docker_compose_files):
-        fail("docker_compose_test: set either docker_compose_file (singular) or docker_compose_files (list), not both")
-    if docker_compose_file != None:
-        return [docker_compose_file]
-    if len(docker_compose_files):
-        return docker_compose_files
-    fail("docker_compose_test: one of docker_compose_file or docker_compose_files must be set")
+    if not len(docker_compose_files):
+        fail("docker_compose_test: docker_compose_files must be a non-empty list")
 
 def _test_data(data, compose_files, pre_compose_up_script, post_compose_down_script):
     data = data + compose_files
@@ -72,8 +65,7 @@ def docker_compose_test(
     *,
     name,
     docker_compose_test_container,
-    docker_compose_file = None,
-    docker_compose_files = [],
+    docker_compose_files,
     pre_compose_up_script = "",
     extra_docker_compose_up_args = "",
     local_image_targets = "",
@@ -83,12 +75,12 @@ def docker_compose_test(
     exclusive = True,
     post_compose_down_script = "",
     **kwargs):
-    compose_files = _resolve_compose_files(docker_compose_file, docker_compose_files)
-    data = _test_data(data, compose_files, pre_compose_up_script, post_compose_down_script)
+    _check_compose_files(docker_compose_files)
+    data = _test_data(data, docker_compose_files, pre_compose_up_script, post_compose_down_script)
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose_test//docker_compose_test:docker_compose_test.sh"],
-        env = _get_env(compose_files, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else _project_base_from_name(name), post_compose_down_script),
+        env = _get_env(docker_compose_files, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else _project_base_from_name(name), post_compose_down_script),
         size = size,
         tags = _test_tags(tags, exclusive),
         data = data,
@@ -99,8 +91,7 @@ def go_docker_compose_test(
     *,
     name,
     docker_compose_test_container,
-    docker_compose_file = None,
-    docker_compose_files = [],
+    docker_compose_files,
     pre_compose_up_script = "",
     extra_docker_compose_up_args = "",
     local_image_targets = "",
@@ -115,9 +106,9 @@ def go_docker_compose_test(
     post_compose_down_script = "",
     **kwargs,
 ):
-    compose_files = _resolve_compose_files(docker_compose_file, docker_compose_files)
+    _check_compose_files(docker_compose_files)
     build_tags = common_tags + tags
-    data = _test_data(data, compose_files, pre_compose_up_script, post_compose_down_script)
+    data = _test_data(data, docker_compose_files, pre_compose_up_script, post_compose_down_script)
     if test_image_base == None:
         fail("if you are defining test_srcs, you need to provide a test_image_base")
 
@@ -171,7 +162,7 @@ def go_docker_compose_test(
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose_test//docker_compose_test:docker_compose_test.sh"],
-        env = _get_env(compose_files, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else _project_base_from_name(name), post_compose_down_script),
+        env = _get_env(docker_compose_files, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else _project_base_from_name(name), post_compose_down_script),
         size = size,
         tags = _test_tags(tags, exclusive),
         data = data,
@@ -183,8 +174,7 @@ def junit_docker_compose_test(
     *,
     name,
     docker_compose_test_container,
-    docker_compose_file = None,
-    docker_compose_files = [],
+    docker_compose_files,
     pre_compose_up_script = "",
     extra_docker_compose_up_args = "",
     local_image_targets = "",
@@ -199,9 +189,9 @@ def junit_docker_compose_test(
     exclusive = True,
     post_compose_down_script = "",
     **kwargs):
-    compose_files = _resolve_compose_files(docker_compose_file, docker_compose_files)
+    _check_compose_files(docker_compose_files)
     build_tags = common_tags + tags
-    data = _test_data(data, compose_files, pre_compose_up_script, post_compose_down_script)
+    data = _test_data(data, docker_compose_files, pre_compose_up_script, post_compose_down_script)
 
     if test_image_base == None:
         fail("if you are defining test_srcs, you need to provide a test_image_base")
@@ -272,7 +262,7 @@ def junit_docker_compose_test(
     native.sh_test(
         name = name,
         srcs = ["@rules_docker_compose_test//docker_compose_test:docker_compose_test.sh"],
-        env = _get_env(compose_files, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else _project_base_from_name(name), post_compose_down_script),
+        env = _get_env(docker_compose_files, local_image_targets, docker_compose_test_container, pre_compose_up_script, extra_docker_compose_up_args, "" if exclusive else _project_base_from_name(name), post_compose_down_script),
         size = size,
         tags = _test_tags(tags, exclusive),
         data = data,

--- a/docker_compose_test/docker_compose_test.bzl
+++ b/docker_compose_test/docker_compose_test.bzl
@@ -69,10 +69,11 @@ def _test_data(data, compose_files, pre_compose_up_script, post_compose_down_scr
     return data
 
 def docker_compose_test(
+    *,
     name,
+    docker_compose_test_container,
     docker_compose_file = None,
     docker_compose_files = [],
-    docker_compose_test_container = None,
     pre_compose_up_script = "",
     extra_docker_compose_up_args = "",
     local_image_targets = "",
@@ -95,10 +96,11 @@ def docker_compose_test(
     )
 
 def go_docker_compose_test(
+    *,
     name,
+    docker_compose_test_container,
     docker_compose_file = None,
     docker_compose_files = [],
-    docker_compose_test_container = None,
     pre_compose_up_script = "",
     extra_docker_compose_up_args = "",
     local_image_targets = "",
@@ -178,10 +180,11 @@ def go_docker_compose_test(
 
 
 def junit_docker_compose_test(
+    *,
     name,
+    docker_compose_test_container,
     docker_compose_file = None,
     docker_compose_files = [],
-    docker_compose_test_container = None,
     pre_compose_up_script = "",
     extra_docker_compose_up_args = "",
     local_image_targets = "",

--- a/docker_compose_test/docker_compose_test.bzl
+++ b/docker_compose_test/docker_compose_test.bzl
@@ -48,8 +48,12 @@ def _project_base_from_name(name):
 
 def _check_compose_files(docker_compose_files):
     # Order in `docker_compose_files` is preserved through to `docker compose
-    # -f <file>` in the same order: later files override earlier files per
-    # Compose's multi-file merge semantics.
+    # -f <file>` in the same order: later files override earlier ones. The
+    # explicit type check catches `docker_compose_files = ":foo.yml"` (a
+    # leftover from the old singular attr) at the call site rather than
+    # deep inside list concatenation.
+    if type(docker_compose_files) != "list":
+        fail("docker_compose_test: docker_compose_files must be a list of labels, got " + type(docker_compose_files))
     if not len(docker_compose_files):
         fail("docker_compose_test: docker_compose_files must be a non-empty list")
 

--- a/docker_compose_test/docker_compose_test.sh
+++ b/docker_compose_test/docker_compose_test.sh
@@ -111,10 +111,9 @@ fi
 # hand. Build a compose_file_args array to pass to every `docker compose`
 # invocation as a repeated `-f <abs-path>` sequence.
 #
-# Compose merges multiple `-f` files with well-defined semantics: later
-# files override earlier files, scalars replace, maps merge by key,
-# sequences replace wholesale. See
-# https://docs.docker.com/reference/compose-file/merge/.
+# Files are passed to Compose in list order; later files override
+# earlier ones. See https://docs.docker.com/reference/compose-file/merge/
+# for Compose's merge rules.
 compose_file_args=()
 while IFS= read -r compose_file; do
     [ -z "$compose_file" ] && continue

--- a/examples/external-image-test/BUILD
+++ b/examples/external-image-test/BUILD
@@ -17,6 +17,6 @@ load("@rules_docker_compose_test//docker_compose_test:docker_compose_test.bzl", 
 
 docker_compose_test(
     name = "external-image-test",
-    docker_compose_file = ":docker-compose.yml",
+    docker_compose_files = [":docker-compose.yml"],
     docker_compose_test_container = "test_container",
 )

--- a/examples/go-test-image-test/BUILD.bazel
+++ b/examples/go-test-image-test/BUILD.bazel
@@ -17,7 +17,7 @@ load("@rules_docker_compose_test//docker_compose_test:docker_compose_test.bzl", 
 
 go_docker_compose_test(
     name = "go-test-image-test",
-    docker_compose_file = ":docker-compose.yml",
+    docker_compose_files = [":docker-compose.yml"],
     docker_compose_test_container = "test_container",
     test_srcs = glob(["**/*_test.go"]),
     test_deps = [],

--- a/examples/junit-image-test/BUILD
+++ b/examples/junit-image-test/BUILD
@@ -17,7 +17,7 @@ load("@rules_docker_compose_test//docker_compose_test:docker_compose_test.bzl", 
 
 junit_docker_compose_test(
     name = "junit-image-test",
-    docker_compose_file = ":docker-compose.yml",
+    docker_compose_files = [":docker-compose.yml"],
     docker_compose_test_container = "test_container",
     test_srcs = glob(["**/*Test.java"]),
     test_deps = ["@maven//:org_junit_jupiter_junit_jupiter_api"],

--- a/examples/locally-built-image-test/BUILD
+++ b/examples/locally-built-image-test/BUILD
@@ -44,7 +44,7 @@ sh_binary(
 
 docker_compose_test(
     name = "locally-built-image-test",
-    docker_compose_file = ":docker-compose.yml",
+    docker_compose_files = [":docker-compose.yml"],
     docker_compose_test_container = "test_container",
     local_image_targets = "locally-built-image-test:tarball",
     data = [":docker_image_fixture"],

--- a/examples/multi-compose-file-test/BUILD
+++ b/examples/multi-compose-file-test/BUILD
@@ -16,9 +16,8 @@
 load("@rules_docker_compose_test//docker_compose_test:docker_compose_test.bzl", "docker_compose_test")
 
 # Demonstrates docker_compose_files (plural). Files are passed to
-# `docker compose -f a -f b` in list order; Compose deep-merges them,
-# with later files overriding earlier ones (scalars replace, maps merge
-# by key, sequences replace wholesale).
+# `docker compose -f a -f b` in list order; later files override earlier
+# ones per Compose's merge rules.
 #
 # base.yml declares a `test_container` service whose entrypoint exits 1
 # (so a run of just the base would fail). override.yml patches the

--- a/examples/non-exclusive-test/BUILD
+++ b/examples/non-exclusive-test/BUILD
@@ -30,7 +30,7 @@ load("@rules_docker_compose_test//docker_compose_test:docker_compose_test.bzl", 
 
 docker_compose_test(
     name = "non-exclusive-test-a",
-    docker_compose_file = ":docker-compose.yml",
+    docker_compose_files = [":docker-compose.yml"],
     docker_compose_test_container = "test_container",
     exclusive = False,
     pre_compose_up_script = ":src/test/resources/setup_test.sh",
@@ -40,7 +40,7 @@ docker_compose_test(
 
 docker_compose_test(
     name = "non-exclusive-test-b",
-    docker_compose_file = ":docker-compose.yml",
+    docker_compose_files = [":docker-compose.yml"],
     docker_compose_test_container = "test_container",
     exclusive = False,
     pre_compose_up_script = ":src/test/resources/setup_test.sh",

--- a/examples/pre-compose-up-script-test/BUILD
+++ b/examples/pre-compose-up-script-test/BUILD
@@ -17,7 +17,7 @@ load("@rules_docker_compose_test//docker_compose_test:docker_compose_test.bzl", 
 
 docker_compose_test(
     name = "pre-compose-up-script-test",
-    docker_compose_file = ":docker-compose.yml",
+    docker_compose_files = [":docker-compose.yml"],
     docker_compose_test_container = "test_container",
     pre_compose_up_script = ":src/test/resources/setup_test.sh",
     extra_docker_compose_up_args = "--quiet-pull --no-color",


### PR DESCRIPTION
## Summary

Follow-up to #51. Two cleanups on all three macros (`docker_compose_test`, `go_docker_compose_test`, `junit_docker_compose_test`):

1. **Every argument is keyword-only.** `*,` at the top of each signature; positional calls fail at load time.
2. **`docker_compose_file` (singular) is removed.** `docker_compose_files` (list) is now required.

## Motivation

#51 grew the two-attr shape (singular + plural) with an "exactly one of" validation helper. That was a compromise to preserve the singular attr for backwards compatibility, but it left an awkward API surface: two attrs that mean the same thing modulo shape, plus a runtime check to catch misuse. Consolidating onto the plural gives users one obvious way to do it and lets the helper collapse into a two-line "list non-empty" guard.

Making everything keyword-only sidesteps the ordering pitfalls #51 introduced (`docker_compose_files` sat between `docker_compose_file` and `docker_compose_test_container` in the signature — positional callers would silently pass the container name as a list) and lets `docker_compose_test_container` drop its `= None` default and be required again.

## Shape of the change

- `docker_compose_test.bzl`:
  - Add `*,` after the opening paren on each of the three macros.
  - Remove the `docker_compose_file` attr from all three signatures.
  - Make `docker_compose_files` a required kw-only arg (no default).
  - Delete `_resolve_compose_files`; replace with a small `_check_compose_files` guard that fails on empty list or non-list value (catches a leftover `docker_compose_files = ":foo.yml"` at the call site).
  - `docker_compose_test_container` moves to the top of the kw-only block and loses its `= None` default (required again).
- **Examples** (6 BUILD files): rewrite `docker_compose_file = ":c.yml"` → `docker_compose_files = [":c.yml"]`.
- **README.md**:
  - Five existing snippets rewritten the same way.
  - "Composing multiple compose files" section trimmed (no more "instead of" / "exactly one of" language).
  - Kept the keyword-only-args note; trimmed the merge-semantics paragraph down to a link to Compose's docs (the previous prose was wrong about sequence merges).
- **MODULE.bazel**: bump `1.4.0` → `2.0.0`. Both changes are load-time breaking for downstream callers, so this is a MAJOR.

## Backwards compatibility

**Breaking.** Every existing caller must:
1. Rewrite `docker_compose_file = ":c.yml"` as `docker_compose_files = [":c.yml"]`.
2. Pass all args by keyword (already the Bazel-idiomatic default; every example in this repo already did so).

The rewrite in (1) is mechanical (`sed`-able) and the load-time failure message points at the missing/empty attr, so migration should be straightforward.

## What I verified locally

- `cd examples && bazel build //...`: clean, all 36 targets build successfully (including the `multi-compose-file-test` from #51).
